### PR TITLE
fix data source loading issues for BaoStock and ccxt

### DIFF
--- a/chan.py-main/Chan.py
+++ b/chan.py-main/Chan.py
@@ -156,7 +156,9 @@ class CChan:
         valid_lv_list = []
         for lv in self.lv_list:
             try:
-                lv_klu_iter.append(self.get_load_stock_iter(stockapi_cls, lv))
+                # 先将数据全部拉取完，避免数据源在多次请求时发生相互影响
+                data_list = list(self.get_load_stock_iter(stockapi_cls, lv))
+                lv_klu_iter.append(iter(data_list))
                 valid_lv_list.append(lv)
             except CChanException as e:
                 if e.errcode == ErrCode.SRC_DATA_NOT_FOUND and self.conf.auto_skip_illegal_sub_lv:

--- a/chan.py-main/DataAPI/ccxt.py
+++ b/chan.py-main/DataAPI/ccxt.py
@@ -1,6 +1,8 @@
 from datetime import datetime
+import time
 
 import ccxt
+from ccxt.base.errors import NetworkError
 
 from Common.CEnum import AUTYPE, DATA_FIELD, KL_TYPE
 from Common.CTime import CTime
@@ -30,9 +32,22 @@ class CCXT(CCommonStockApi):
     def get_kl_data(self):
         fields = "time,open,high,low,close"
         exchange = ccxt.binance()
+        # 部分环境下访问交易所接口可能出现SSL错误，关闭校验以提升兼容性
+        exchange.session.verify = False
         timeframe = self.__convert_type()
         since_date = exchange.parse8601(f'{self.begin_date}T00:00:00')
-        data = exchange.fetch_ohlcv(self.code, timeframe, since=since_date)
+
+        # 简单的重试机制，增强网络异常时的容错
+        for retry in range(3):
+            try:
+                data = exchange.fetch_ohlcv(self.code, timeframe, since=since_date)
+                break
+            except NetworkError:
+                if retry == 2:
+                    raise
+                time.sleep(1)
+        else:
+            data = []
 
         for item in data:
             time_obj = datetime.fromtimestamp(item[0] / 1000)


### PR DESCRIPTION
## Summary
- prefetch k-line data per level to avoid BaoStock minute data loss when mixing day and minute queries
- improve ccxt data source stability by disabling SSL verification and retrying on network errors

## Testing
- `python -m py_compile Chan.py DataAPI/ccxt.py`


------
https://chatgpt.com/codex/tasks/task_e_68a20351617c832f9762e1fa95fc15e9